### PR TITLE
Remove procps

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -63,8 +63,7 @@
 						'<!@(<(pkg-config) --cflags xcb-shm)',
 						'<!@(<(pkg-config) --cflags xcb-composite)',
 						'<!@(<(pkg-config) --cflags xcb-record)',
-						'<!@(<(pkg-config) --cflags xcb-shape)',
-						'<!@(<(pkg-config) --cflags libprocps)'
+						'<!@(<(pkg-config) --cflags xcb-shape)'
 					],
 					'ldflags': [
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb)',
@@ -72,8 +71,7 @@
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-shm)',
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-composite)',
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-record)',
-						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-shape)',
-						'<!@(<(pkg-config) --libs-only-L --libs-only-other libprocps)'
+						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-shape)'
 					],
 					'libraries': [
 						'<!@(<(pkg-config) --libs-only-l xcb)',
@@ -81,8 +79,7 @@
 						'<!@(<(pkg-config) --libs-only-l xcb-shm)',
 						'<!@(<(pkg-config) --libs-only-l xcb-composite)',
 						'<!@(<(pkg-config) --libs-only-l xcb-record)',
-						'<!@(<(pkg-config) --libs-only-l xcb-shape)',
-						'<!@(<(pkg-config) --libs-only-l libprocps)'
+						'<!@(<(pkg-config) --libs-only-l xcb-shape)'
 					],
 					"cflags_cc": [ "-std=c++17" ],
 				}],

--- a/flake.nix
+++ b/flake.nix
@@ -8,16 +8,8 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        procpsOrig = pkgs.procps.overrideAttrs (oldAttrs: {
-          version = "3.3.17";
-          src = pkgs.fetchurl {
-            url = "mirror://sourceforge/procps-ng/procps-ng-3.3.17.tar.xz";
-            hash = "sha256-RRiz56r9NOwH0AY9JQ/UdJmbILIAIYw65W9dIRPxQbQ=";
-          };
-        });
 
         x11Deps = with pkgs; [
-          procpsOrig
           pkg-config
           xorg.libxcb
           xorg.xcbutilwm
@@ -64,7 +56,6 @@
           pkgs.libglvnd
           pkgs.libudev0-shim
           pkgs.nodejs
-          pkgs.procps
           pkgs.pkg-config
           pkgs.gcc
 

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -2,7 +2,6 @@
 #include <memory>
 #include <iostream>
 #include <napi.h>
-#include <proc/readproc.h>
 #include <xcb/composite.h>
 #include <xcb/record.h>
 #include <xcb/shape.h>


### PR DESCRIPTION
procps is deprecated in most distros, and isn't actually needed in this project.

See https://github.com/skillbert/alt1-electron/pull/53 for details,