### PR TITLE
Correct off-by-one error in OSSetWindowShape

### DIFF
--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -304,7 +304,7 @@ void OSSetWindowShape(OSWindow window, std::vector<JSRectangle> rects) {
 	uint8_t ordering = 0;
 	if (xrects.size() < 2) ordering = 3;
 	//TODO this 5k x 5k special case is weird, implement separate clear call again?
-	if (rects.size() == 1 && rects[1].width >= 5000 && rects[1].height >= 5000) {
+	if (rects.size() == 1 && rects[0].width >= 5000 && rects[0].height >= 5000) {
 		xcb_shape_mask(connection, 0, XCB_SHAPE_SK_INPUT, window.handle, 0, 0, 0);
 	}
 	else {


### PR DESCRIPTION
Fixes the following error that can be observed in certain desktop environments (observed primarily in Gnome 49):
`/usr/include/c++/15/bits/stl_vector.h:1263: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator [with _Tp = JSRectangle; _Alloc = std::allocator; reference = JSRectangle&; size_type = long unsigned int]: Assertion '_n < this->size()' failed.`

TEST: manual
  1. Run Clue Trainer or Cluesolver through Alt1 (in `npm run ui`)
  2. Perform clue scan, or generally interact with the game and either App
  3. Monitor the state of Alt1 and ensure that the App is still alive