### PR TITLE
Add dummy status daemon

### DIFF
--- a/src/appframe/alt1api.ts
+++ b/src/appframe/alt1api.ts
@@ -191,6 +191,18 @@ var alt1api: Partial<typeof alt1> = {
 	overLayRefreshGroup(groupid) { queueOverlayCommand({ command: "refreshgroup", groupid }); },
 	setTooltip(str) { setTooltip(str); return true; },
 	clearTooltip() { setTooltip(""); },
+	registerStatusDaemon(serverUrl: string, state: string) {
+		return JSON.stringify({
+			state: "",
+			nextRun: 100,
+			alerts: [{ title: "", body: "" }],
+			status: [{ status: "" }],
+		});
+	},
+
+	getStatusDaemonState() {
+		return "";
+	},
 
 	//new API's
 	capture(x, y, width, height) {


### PR DESCRIPTION
Fixes #13 at least, but obviously anything that actually has a hard dependency on the functionality still won't work.