### PR TITLE
Move nightly tag to point at latest commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,14 @@ jobs:
           npm run build
           npx electron-builder -l --publish never
 
+      - name: Move nightly tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X PATCH \
+            repos/${{ github.repository }}/git/refs/tags/nightly \
+            -f sha="${GITHUB_SHA}"
+
       - name: Publish rolling Nightly release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should solve the source code not being updated. It worked in my repo at least. It is just telling the release to point at the latest commit, however it does not change this part:
<img width="877" height="60" alt="image" src="https://github.com/user-attachments/assets/52da74f1-b9dc-4567-89a5-11a27f3acd59" />
